### PR TITLE
Update logo img URL to github.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Aalto-yliopiston Mahjong-yhdistyksen nettisivut, Otaniemi, Finland">
     <meta name="keywords" content="Mahjong, College, Yliopisto, Otaniemi, Finland, Espoo, Aalto-yliopisto, Aalto, Association, Yhdistys">
-    <meta property="og:image" content="https://mahjong.ayy.fi/img/logo.png">
+    <meta property="og:image" content="https://aaltomahjong.github.io/img/logo.png">
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="821">
     <meta property="og:image:height" content="821">


### PR DESCRIPTION
Was still left as mahjong.ayy.fi, which no longer loads