### PR TITLE
Aallonharja 2025

### DIFF
--- a/partials/home.html
+++ b/partials/home.html
@@ -12,6 +12,26 @@
 <h1 class="en-text">Latest news</h1>
 
 <div class="greatwave">
+  <h3>16.06.2025 - <a href="#/turnaus-ah25">Aallonharja 2025</a></h3>
+  <p class="fi-text">
+    Aalto Daigaku Maajanbu ry järjestää kahdeksan hanchanin MFRS-rekisteröidyn Aallonharja-turnauksen
+    elokuussa Aalto Design Factorylla Otaniemessä,
+    pelaajamääränä alustavasti 60.
+    <a href="#/turnaus-ah25">
+      Infoa turnauksesta ja ohjeet osallistumiseen löydät täältä.
+    </a>
+  </p>
+  <p class="en-text">
+    The 8-hanchan MFRS Aallonharja tournament
+    will be held in April at Aalto Design Factory in Otaniemi, Espoo.
+    There will be at least 60 seats.
+    <a href="#/turnaus-ah25">
+      Further information about the tournament and registration instructions can be found here.
+    </a>
+  </p>
+</div>
+
+<div class="greatwave">
   <h3>11.01.2025 - <a href="#/turnaus-gw25">Great Wave 2025</a></h3>
   <p class="fi-text">Aalto Daigaku Maajanbu ry järjestää kahdeksan hanchanin MERS-rekisteröidyn Great Wave-turnauksen huhtikuussa Aalto Design Factorylla Otaniemessä, pelaajamääränä alustavasti 60. <a href="#/turnaus-gw25">Infoa turnauksesta ja ohjeet osallistumiseen löydät täältä.</a></p>
   <p class="en-text">The 8-hanchan MERS Great Wave tournament will be held in April at Aalto Design Factory in Otaniemi, Espoo. There will be at least 60 seats. <a href="#/turnaus-gw25">Further information about the tournament and registration instructions can be found here.</a></p>

--- a/partials/turnaus-ah25.html
+++ b/partials/turnaus-ah25.html
@@ -1,0 +1,210 @@
+﻿<h1>Aallonharja 2025</h1>
+
+<section class="fi-text">
+  <p>
+    <!--Google forms, nimi, maili, puhnro?, allergiat?, setti/matto?, maksutapa, lounas, valokuvat -->
+    <a href="https://forms.gle/XzQqxLsQAgKMQtfR6">Ilmoittautumislomakkeeseen tästä!</a>
+  </p>
+  <p>
+    Aalto Daigaku Maajanbu ry järjestää elokuussa 16.–17.8.2025 kaksipäiväisen mahjongtunauksen Otaniemessä!
+    Mukaan mahtuu 60 pelaajaa,
+    ja turnaus on Suomen MFRS-järjestelmässä.
+  </p>
+</section>
+<section class="en-text">
+  <p>
+    <!--Google forms, nimi, maili, puhnro?, allergiat?, setti/matto?, maksutapa, lounas, valokuvat -->
+    <a href="https://forms.gle/XzQqxLsQAgKMQtfR6">Registration form here!</a>
+  </p>
+  <p>
+    Aalto Daigaku Maajanbu ry is organizing a two-day mahjong tournament August 16th–17th, in Otaniemi, Espoo!
+    The tournament has room for 60 people,
+    and will be MFRS (Mahjong Finland ranking system) ranked.
+  </p>
+</section>
+
+<section class="fi-text">
+  <h3>Sijainti</h3>
+  <p>
+    Turnaus järjestetään Aalto Design Factorylla Otaniemessä,
+    parin minuutin kävelymatkan päässä Otaniemen metroasemalta.
+    Osoite on Puumiehenkuja 5, 02150 Espoo.
+    Matkan suunnittelussa auttaa
+    <a href="https://reittiopas.hsl.fi/reitti/-/Puumiehenkuja%205%2C%20Espoo%3A%3A60.187838%2C24.824478?locale=fi&setTime=true&time=1755332100">
+      HSL:n reittiopas
+    </a>.
+  </p>
+  <p>
+    Turnaukseen järjestetään halukkaille lounastarjoilu lisähintaan.
+    Jos et halua tilata paikalle toimitettua lounasta,
+    turnauspaikan lähistöllä on myös useita ravintoloita kävelyetäisyydellä,
+    ja yhden metropysäkin päässä on Tapiolan ostoskeskus.
+    Paikan päällä on myös kaikille tarjolla pikkupurtavaa. 
+  </p>
+</section>
+<section class="en-text">
+  <h3>Location</h3>
+  <p>
+    The tournament will be held at Aalto Design Factory,
+    a few minutes’ walk from the Otaniemi metro station.
+    The address is Puumiehenkuja 5, 02150 Espoo.
+    To help plan your trip, you can use
+    <a href="https://reittiopas.hsl.fi/reitti/-/Puumiehenkuja%205%2C%20Espoo%3A%3A60.187838%2C24.824478?locale=en&setTime=true&time=1755332100">
+      the HSL public transport route planner
+    </a>.
+  </p>
+  <p>
+    The tournament will have lunch catering for an additional cost.
+    If you do not want to order lunch,
+    there are some restaurants within walking distance,
+    as well as quickly accessible by subway.
+    There are also light snacks available for everyone.
+  </p>
+</section>
+
+<section>
+  <h3 class="fi-text">Aikataulu<!-- (<a href="img/Great_Wave_2024.ics">Lisää kalenteriin</a>)--></h3>  
+  <h3 class="en-text">Schedule<!-- (<a href="img/Great_Wave_2024.ics">Import to calendar</a>)--></h3>
+  <table class="tournament-schedule">
+    <tr>
+      <td colspan="2" class="fi-text">Lauantai</td>
+      <td colspan="2" class="en-text">Saturday</td>
+      <td colspan="2" class="fi-text">Sunnuntai</td>
+      <td colspan="2" class="en-text">Sunday</td>
+    </tr>
+    <tr>
+      <td colspan="2"></td>
+      <td>9:30–11:00</td>
+      <td class="fi-text">5. Hanchan</td>
+      <td class="en-text">5th Hanchan</td>
+    </tr>
+    <tr>
+      <td>11:15–11:45</td>
+      <td class="fi-text">Ilmoittautuminen</td>
+      <td class="en-text">Registration</td>
+      <td>11:15–12:45</td>
+      <td class="fi-text">6. Hanchan</td>
+      <td class="en-text">6th Hanchan</td>
+    </tr>
+    <tr>
+      <td>12:00–13:30</td>
+      <td class="fi-text">1. Hanchan</td>
+      <td class="en-text">1st Hanchan</td>      
+      <td>12:45–13:45</td>
+      <td class="fi-text">Lounastauko</td>
+      <td class="en-text">Lunch break</td>
+    </tr>
+    <tr>
+      <td>13:45–15:15</td>
+      <td class="fi-text">2. Hanchan</td>
+      <td class="en-text">2nd Hanchan</td>
+      <td>13:45–15:15</td>
+      <td class="fi-text">7. Hanchan</td>
+      <td class="en-text">7th Hanchan</td>
+    </tr>
+    <tr>
+      <td>15:15–16:15</td>
+      <td class="fi-text">Lounastauko</td>
+      <td class="en-text">Lunch break</td>
+      <td>15:30–17:00</td>
+      <td class="fi-text">8. Hanchan</td>
+      <td class="en-text">8th Hanchan</td>
+    </tr>
+    <tr>
+      <td>16:15–17:45</td>
+      <td class="fi-text">3. Hanchan</td>
+      <td class="en-text">3rd Hanchan</td>
+      <td>17:15–17:30</td>
+      <td class="fi-text">Palkintojenjako</td>
+      <td class="en-text">Award Ceremony</td>
+    </tr>
+    <tr>
+      <td>18:00–19:30</td>
+      <td class="fi-text">4. Hanchan</td>
+      <td class="en-text">4th Hanchan</td>
+      <td colspan="2"></td>
+    </tr>
+  </table>
+</section>
+
+<!-- <section>
+  <h3 class="fi-text">Ilmoittautuneet osallistujat</h3>  
+  <h3 class="en-text">Registered participants</h3>
+  <p>
+  </p>
+  <p>
+    Total: 0/60.
+    <span class="fi-text">Päivitetty</span><span class="en-text">Updated</span>
+    17:45, 16.06.2025 (EET (UTC+2))
+  </p>
+</section> -->
+
+<section class="fi-text">
+  <h3>Turnausmaksu ja ilmoittautuminen</h3>
+  <p>
+    Turnaukseen osallistuminen maksaa 10€.
+    Hintaan sisältyy kahvia ja teetä sekä pikkupurtavaa.
+    Lisäksi voit tilata lounastarjoilun molemmille päiville.
+    Lounaan yksityiskohdat (ml. hinta) tarkentuvat pikimmiten.
+  </p>
+  <p>
+    Turnaukseen mahtuu 60 pelaajaa,
+    minkä jälkeen ilmoittautuneet menevät varasijoille.
+    Ilmoittautuminen sulkeutuu perjantaina 8.8.
+    Pyydämme, että osallistumismaksut maksettaisiin seuran tilille myös tähän mennessä.
+    Deadlinen jälkeen ilmoittautuminen on sitova
+    eikä maksettuja osallistumismaksuja palauteta!
+  </p>
+  <p>
+    Aalto Daigaku Maajanbu ry <br/>
+    FI81 5780 4120 0541 73 OKOYFIHH (Osuuspankki) 
+  </p>
+  <p>
+    Laita maksun tekstikenttään “Aallonharja 2025” ja nimesi.
+    Esim. “Aallonharja 2025, Matti Meikäläinen”.
+    Jos maksat usealle osallistujalle yhtä aikaa,
+    sisällytäthän viestiin kaikkien nimet.
+  </p>
+  <p>
+    <b>Kysymyksiä? Ota yhteyttä:</b>
+    <a href="mailto:aaltomahjong-hallitus@googlegroups.com">
+      aaltomahjong-hallitus@googlegroups.com
+    </a>
+
+  </p>
+</section>
+<section class="en-text">
+  <h3>Tournament fee and registration</h3>
+  <p>
+    Participation in the tournament costs 10€.
+    The price includes tea, coffee, and light snacks.
+    You can also order lunch for both days for an extra cost.
+    Details will be updated as soon as possible.
+  </p>
+  <p>
+    There are 60 spots in the tournament.
+    After this, you can still sign up for reserve spots,
+    and will get in if someone cancels their registration.
+    Deadline for registration is Friday August 8th.
+    Players from abroad are allowed to pay on-site.
+    However, if possible, we ask that you kindly pay the participation fee to our club’s bank account before the registration deadline.
+    After the deadline the registration is binding
+    and paid tournament fees will not be returned!
+  </p>
+  <p>
+    Aalto Daigaku Maajanbu ry <br/>
+    FI81 5780 4120 0541 73 OKOYFIHH
+  </p>
+  <p>
+    Include “Aallonharja 2025” and your name in the payment text field.
+    For example: “Aallonharja 2025, John Smith”.
+    If you're paying for multiple players at once,
+    please include all their names.
+  </p>
+  <p>
+    <b>Any questions? Contact:</b>
+    <a href="mailto:aaltomahjong-hallitus@googlegroups.com">
+      aaltomahjong-hallitus@googlegroups.com
+    </a>
+  </p>
+</section>

--- a/partials/turnaus-ah25.html
+++ b/partials/turnaus-ah25.html
@@ -36,7 +36,7 @@
   </p>
   <p>
     Turnaukseen järjestetään halukkaille lounastarjoilu lisähintaan.
-    Jos et halua tilata paikalle toimitettua lounasta,
+    Jos haluat mieluummin syödä muualla,
     turnauspaikan lähistöllä on myös useita ravintoloita kävelyetäisyydellä,
     ja yhden metropysäkin päässä on Tapiolan ostoskeskus.
     Paikan päällä on myös kaikille tarjolla pikkupurtavaa. 
@@ -55,10 +55,10 @@
   </p>
   <p>
     The tournament will have lunch catering for an additional cost.
-    If you do not want to order lunch,
+    If you would rather get lunch from a nearby restaurant of your choosing,
     there are some restaurants within walking distance,
     as well as quickly accessible by subway.
-    There are also light snacks available for everyone.
+    There will also be light snacks available for everyone.
   </p>
 </section>
 
@@ -90,7 +90,7 @@
       <td>11:45–13:15</td>
       <td class="fi-text">1. Hanchan</td>
       <td class="en-text">1st Hanchan</td>      
-      <td>12:45–13:45</td>
+      <td>12:45–14:00</td>
       <td class="fi-text">Lounastauko</td>
       <td class="en-text">Lunch break</td>
     </tr>

--- a/partials/turnaus-ah25.html
+++ b/partials/turnaus-ah25.html
@@ -30,7 +30,7 @@
     parin minuutin kävelymatkan päässä Otaniemen metroasemalta.
     Osoite on Puumiehenkuja 5, 02150 Espoo.
     Matkan suunnittelussa auttaa
-    <a href="https://reittiopas.hsl.fi/reitti/-/Puumiehenkuja%205%2C%20Espoo%3A%3A60.187838%2C24.824478?locale=fi&setTime=true&time=1755332100">
+    <a href="https://reittiopas.hsl.fi/reitti/-/Puumiehenkuja%205%2C%20Espoo%3A%3A60.187838%2C24.824478?locale=fi&setTime=true&time=1755331200">
       HSL:n reittiopas
     </a>.
   </p>
@@ -49,7 +49,7 @@
     a few minutes’ walk from the Otaniemi metro station.
     The address is Puumiehenkuja 5, 02150 Espoo.
     To help plan your trip, you can use
-    <a href="https://reittiopas.hsl.fi/reitti/-/Puumiehenkuja%205%2C%20Espoo%3A%3A60.187838%2C24.824478?locale=en&setTime=true&time=1755332100">
+    <a href="https://reittiopas.hsl.fi/reitti/-/Puumiehenkuja%205%2C%20Espoo%3A%3A60.187838%2C24.824478?locale=en&setTime=true&time=1755331200">
       the HSL public transport route planner
     </a>.
   </p>
@@ -79,7 +79,7 @@
       <td class="en-text">5th Hanchan</td>
     </tr>
     <tr>
-      <td>11:15–11:45</td>
+      <td>11:00–11:30</td>
       <td class="fi-text">Ilmoittautuminen</td>
       <td class="en-text">Registration</td>
       <td>11:15–12:45</td>
@@ -87,7 +87,7 @@
       <td class="en-text">6th Hanchan</td>
     </tr>
     <tr>
-      <td>12:00–13:30</td>
+      <td>11:45–13:15</td>
       <td class="fi-text">1. Hanchan</td>
       <td class="en-text">1st Hanchan</td>      
       <td>12:45–13:45</td>
@@ -95,18 +95,18 @@
       <td class="en-text">Lunch break</td>
     </tr>
     <tr>
-      <td>13:45–15:15</td>
+      <td>13:30–15:00</td>
       <td class="fi-text">2. Hanchan</td>
       <td class="en-text">2nd Hanchan</td>
-      <td>13:45–15:15</td>
+      <td>14:00–15:30</td>
       <td class="fi-text">7. Hanchan</td>
       <td class="en-text">7th Hanchan</td>
     </tr>
     <tr>
-      <td>15:15–16:15</td>
+      <td>15:00–16:15</td>
       <td class="fi-text">Lounastauko</td>
       <td class="en-text">Lunch break</td>
-      <td>15:30–17:00</td>
+      <td>15:45–17:15</td>
       <td class="fi-text">8. Hanchan</td>
       <td class="en-text">8th Hanchan</td>
     </tr>
@@ -114,7 +114,7 @@
       <td>16:15–17:45</td>
       <td class="fi-text">3. Hanchan</td>
       <td class="en-text">3rd Hanchan</td>
-      <td>17:15–17:30</td>
+      <td>17:30–17:45</td>
       <td class="fi-text">Palkintojenjako</td>
       <td class="en-text">Award Ceremony</td>
     </tr>


### PR DESCRIPTION
Tournament info page.

Text formatted with [semantic line breaks](https://sembr.org/) for editing convenience, but will render as normal paragraphs in browsers. (it might be a good idea to retroactively do the same for old posts as well? but that's outside the scope of this)